### PR TITLE
Update hmupdater.user.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Ce script permet à un joueur du [jeu hordes](http://www.hordes.fr/) de disposer
 
 Le script permet de mettre à jour un ou plusieurs des sites suivants :
 
- - la [PataM@p](http://www.patamap.com/)
+ - la PataM@p  (N’est plus en service)
  - [BigBroth’Hordes](http://bbh.fred26.fr/)
  - Ultimate Manager (N’est plus en service)
  - « Où En Êtes-Vous ? » (N’est plus en service)

--- a/hmupdater.user.js
+++ b/hmupdater.user.js
@@ -38,11 +38,7 @@ const GM_AVAILABLE = (typeof(GM_getValue) != 'undefined' && !window.chrome && !w
 // Maps externes bénéficiant d’un accès sécurisé au flux du site hordes.fr
 //
 var webapps = {};
-webapps['Patamap'] = { id: 9,  url: 'http://patamap.com/hmupdater.php', label: 'la Patamap', key: null, xml: true };
 webapps['BBH']     = { id: 51, url: 'http://bbh.fred26.fr/update.php', label: 'BigBroth\'Hordes', key: null, xml: true };
-webapps['HUM']     = { id: 36, url: 'http://www.hordes-ultimate-manager.net/hmupdater/index.php', label: 'Ultimate Manager', key: null, xml: true };
-webapps['LCN']     = { id: 14, url: 'http://www.lacitadellenoire.com/carte.php', label: 'La Citadelle Noire', key: null, xml: false };
-webapps['OEEV']    = { id: 22, url: 'http://www.oeev-hordes.com/', label: 'OEEV', key: null, xml: false };
 
 // Localisation
 var lang = {};

--- a/hmupdater.user.js
+++ b/hmupdater.user.js
@@ -17,12 +17,12 @@
 // @namespace      http://dev.webnaute.net/Applications/HMUpdater
 // @description    Mise à jour d'une M@p d'objets à partir de hordes.fr
 // @include        http://www.hordes.fr/*
-// @version        1.7
+// @version        1.8
 // ==/UserScript==
 
 (function(){
 
-const HMU_VERSION  = '1.7';
+const HMU_VERSION  = '1.8';
 const HMU_APPNAME  = 'HMUpdater';
 const HMU_TIMEOUT  = 10;// en secondes
 const HMU_APPHOME  = 'http://dev.webnaute.net/Applications/HMUpdater/';
@@ -40,6 +40,9 @@ const GM_AVAILABLE = (typeof(GM_getValue) != 'undefined' && !window.chrome && !w
 var webapps = {};
 webapps['Patamap'] = { id: 9,  url: 'http://patamap.com/hmupdater.php', label: 'la Patamap', key: null, xml: true };
 webapps['BBH']     = { id: 51, url: 'http://bbh.fred26.fr/update.php', label: 'BigBroth\'Hordes', key: null, xml: true };
+webapps['HUM']     = { id: 36, url: 'http://www.hordes-ultimate-manager.net/hmupdater/index.php', label: 'Ultimate Manager', key: null, xml: true };
+webapps['LCN']     = { id: 14, url: 'http://www.lacitadellenoire.com/carte.php', label: 'La Citadelle Noire', key: null, xml: false };
+webapps['OEEV']    = { id: 22, url: 'http://www.oeev-hordes.com/', label: 'OEEV', key: null, xml: false };
 
 // Localisation
 var lang = {};
@@ -724,9 +727,12 @@ HMUpdater.sendData = function(webapp, doc) {
 		xhr.onload = function() {
 			if( /name=\"key\"\s+value=\"([a-zA-Z0-9]+)\"/.test(this.responseText) ) {
 				webapp.key = RegExp.$1;
+				HMUpdater.sendData(webapp, doc);
+			} else {
+				console.log('Unable to get secret key for webapp ' + webapp.label);
+				webapp.done = true;
+				HMUpdater.finishUpdate();
 			}
-			
-			HMUpdater.sendData(webapp, doc);
 		};
 		xhr.send(null);
 		

--- a/version.php
+++ b/version.php
@@ -2,7 +2,7 @@
 
 header('Cache-Control: public, max-age=3600');
 
-define('HMU_LAST_VERSION', '1.4');
+define('HMU_LAST_VERSION', '1.8');
 
 $output = !empty($_GET['output']) ? trim($_GET['output']) : '';
 


### PR DESCRIPTION
Correction de la boucle infinie lorsque l'on tente de mettre à jour un site qui n'existe plus.
Passage en version 1.8 pour notifier ce changement plutôt conséquent.
Réinsertion des anciennes webapp au cas où elles redeviennent fonctionnelles un jour.
